### PR TITLE
Agregar puertos 4200 y 4201 a la lista blanca de CORS

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -18,7 +18,7 @@ validateConfig();
 
 app.use(express.json());
 
-const whitelist = [ 'http://localhost:8080', 'http://localhost:8081' ]
+const whitelist = [ 'http://localhost:4200', 'http://localhost:4201', 'http://localhost:8080', 'http://localhost:8081' ]
 const options = {
   origin: (origin, callback) => {
     if ( whitelist.includes(origin) || !origin) {


### PR DESCRIPTION
## Issue Vinculado

Closes #5

## Tipo de PR

- [x] Nueva funcionalidad (type:feature)

## Resumen

- Agrega los puertos 4200 y 4201 a la lista blanca de CORS en `api/index.js`
- Permite conexiones desde el frontend ejecutÃ¡ndose en estos nuevos puertos
- Mantiene los puertos existentes (8080, 8081) para compatibilidad

## Cambios

| Archivo | Cambio |
|---------|--------|
| `api/index.js` | Se agregaron `http://localhost:4200` y `http://localhost:4201` al array `whitelist` de CORS |

## Plan de Pruebas

- [x] Verificar que el servidor inicia correctamente con la nueva configuraciÃ³n
- [x] Confirmar que las solicitudes desde los puertos 4200 y 4201 no son bloqueadas por CORS
- [x] Validar que los puertos anteriores (8080, 8081) siguen funcionando

## Checklist del Contribuidor

- [x] Se vincular un issue
- [x] Se usar formato de conventional commits (`chore: agregar puertos 4200 y 4201 a la lista blanca de CORS`)
- [x] No se agregar `Co-Authored-By`
- [x] Cambios probados manualmente
